### PR TITLE
Fix SNS AuthorizationErrorException - Add publish permission

### DIFF
--- a/lib/notification-service-stack.ts
+++ b/lib/notification-service-stack.ts
@@ -63,6 +63,9 @@ exports.handler = async (event) => {
       `),
     });
 
+    // Grant SNS publish permission to fix AuthorizationErrorException
+    notificationTopic.grantPublish(notificationLambda);
+
     // Add tags
     cdk.Tags.of(this).add('GitHubRepo', 'dinindunz/notification-service');
     cdk.Tags.of(this).add('Service', 'NotificationService');


### PR DESCRIPTION
## Issue
Lambda function `notification-service` failing with `AuthorizationErrorException` when publishing to SNS topic.

**Error Details:**
- Error: `SNS:Publish` action not allowed
- Topic: `arn:aws:sns:ap-southeast-2:722141136946:user-notifications`
- Timestamp: 2025-07-31T12:34:29.608Z

## Root Cause
Lambda execution role missing `SNS:Publish` permission for the `user-notifications` topic.

## Solution
**Minimal fix**: Added single line `notificationTopic.grantPublish(notificationLambda);` to grant required permission.

## Changes
- Added: `notificationTopic.grantPublish(notificationLambda);` after Lambda function definition
- No other changes to existing code or architecture

This resolves the authorization error allowing the Lambda to publish to SNS.