### PR TITLE
Fix SNS:Publish permission for notification-service Lambda (CO-6)

### DIFF
--- a/lib/notification-service-stack.ts
+++ b/lib/notification-service-stack.ts
@@ -63,6 +63,9 @@ exports.handler = async (event) => {
       `),
     });
 
+    // Grant SNS publish permission to the Lambda function
+    notificationTopic.grantPublish(notificationLambda);
+
     // Add tags
     cdk.Tags.of(this).add('GitHubRepo', 'dinindunz/notification-service');
     cdk.Tags.of(this).add('Service', 'NotificationService');


### PR DESCRIPTION
## Issue
Fixes Jira ticket: [CO-6](https://dinindunz.atlassian.net/browse/CO-6)

**Error**: `AuthorizationErrorException` - Lambda function `notification-service` cannot publish to SNS topic `user-notifications`

**Root Cause**: Lambda execution role lacks `SNS:Publish` permission for the topic

## Solution
Added `notificationTopic.grantPublish(notificationLambda)` to grant the necessary SNS:Publish permission to the Lambda function's execution role.

## Changes
- **lib/notification-service-stack.ts**: Added single line to grant SNS publish permission

## Testing
After deployment, the Lambda function will be able to successfully publish messages to the SNS topic without authorization errors.

## Impact
- ✅ Resolves notification functionality
- ✅ Minimal code change - single line addition
- ✅ Follows AWS CDK best practices for permission management