### PR TITLE
Add SNS publish permission to Lambda role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_role" "lambda_role" {
+  name = "notification-service-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_sns_policy" {
+  name = "lambda-sns-publish-policy"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sns:Publish"
+        Resource = "arn:aws:sns:ap-southeast-2:722141136946:user-notifications"
+      }
+    ]
+  })
+}
+
+# Basic Lambda execution policy for CloudWatch Logs
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-2"
+}


### PR DESCRIPTION
## Problem Statement
The Lambda function needs permission to publish messages to the SNS topic `user-notifications`.

## Solution
Added IAM role configuration with the required SNS publish permission for the Lambda function.

## Changes Made
- [x] Created main Terraform configuration
- [x] Created IAM role for Lambda with:
  - Basic Lambda execution policy for CloudWatch Logs
  - Custom policy for SNS publish permission to specific topic

## Testing
- [ ] Run `terraform plan` to verify syntax and changes
- [ ] Deploy to development environment
- [ ] Verify Lambda can publish to SNS topic

## Deployment Notes
This change adds the following IAM policy to the Lambda role:
```json
{
    "Effect": "Allow",
    "Action": "sns:Publish",
    "Resource": "arn:aws:sns:ap-southeast-2:722141136946:user-notifications"
}
```

## Rollback Plan
If issues occur:
1. Revert the commits
2. Run `terraform apply` with previous version